### PR TITLE
fix stop after errors

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,6 +1,6 @@
-scripts\cleanup.bat
-scripts\upgrade_all.bat
+call scripts\cleanup.bat
+call scripts\upgrade_all.bat
 
-scripts\vcredist.bat
-scripts\dotnet.bat
-scripts\software.bat
+call scripts\vcredist.bat
+call scripts\dotnet.bat
+call scripts\software.bat


### PR DESCRIPTION
Выполнение install.cmd может остановиться, если вызов scripts\*.bat завершился ошибкой.